### PR TITLE
@pieces.app/client --> @pieces.app/pieces-client-os naming in readme + references throughout the project

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ You can also visit our user facing documentation to learn more about different f
 Using npm:
 
 ```bash
-npm install @pieces.app/client
+npm install @pieces.app/pieces-os-client
 ```
 
 Using pnpm:

--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
-# Get Started with Pieces OS and the @pieces.app/client npm package
+# Get Started with Pieces OS and the @pieces.app/pieces-os-client npm package
 
 Follow this guide to get an early look at using Pieces OS in your own development environment. You can use this to get familiar with some key terms and endpoints: `assets`, `asset`, `connect`, `format`, `formats`, and `create`. There are other topics that are touched on, and further expansion on this starter project is coming soon. 
 
 See the NPM package here: 
-- [https://www.npmjs.com/package/@pieces.app/client](https://www.npmjs.com/package/@pieces.app/client)
+- [https://www.npmjs.com/package/@pieces.app/pieces-os-client](https://www.npmjs.com/package/@pieces.app/pieces-os-client)
 
 Read our Current Documentation:
 - [https://docs.pieces.app](https://docs.pieces.app)
@@ -66,19 +66,19 @@ npm install @pieces.app/client
 Using pnpm:
 
 ```bash
-pnpm add @pieces.app/client
+pnpm add @pieces.app/pieces-os-client
 ```
 
 After you install the package, you  can import the library into your file(s) using `require`:
 
 ```js
-const pieces = require('@pieces.app/client')
+const pieces = require('@pieces.app/pieces-os-client')
 ```
 
 or you can import the package using `import` as well:
 
 ```js
-import * as pieces from '@pieces.app/client'
+import * as pieces from '@pieces.app/pieces-os-client'
 ```
 
 > **Recommendation**
@@ -261,10 +261,10 @@ const tracked_application = {
 - **platform**: Depending on your current environment, you need to set the platform parameter to match your current operating system. Select between `.Macos`, `.Windows`, `.Linux`
 
 > **Imports**
-> Be sure to double-check that you have the following import added to the first few lines of your `index.tsx` file if you have not already: `import * as Pieces from "@pieces.app/client";`
+> Be sure to double-check that you have the following import added to the first few lines of your `index.tsx` file if you have not already: `import * as Pieces from "@pieces.app/pieces-os-client";`
 
 ### Creating `connect()` Function
-When your program starts, it needs to connect to Pieces OS to gain access to any functional data and to exchange information on the `localhost:1000` route. Now that you have your `tracked_application` - lets get into the into the details.
+When your program starts, it needs to connect to Pieces OS to gain access to any functional data and to exchange information on the `localhost:1000` route. Now that you have your `tracked_application` - lets get into the details.
 
 Start by defining you connect function and add the initial `/connect` route to your function as the `url` variable and then attach the `options` object. Include your `tracked_application` object passed into a `JSON.stringify()` method under the `application` parameter like so:
 
@@ -574,7 +574,7 @@ After a successful delete, you may have to reload your browser window in order t
 
 
 ## Conclusion
-This is a very simple guide on how to get up and running using the @pieces.app/client npm package and create a web environment that you can build on top of. **Fork this repo** to get started and learn about the depth of possibilities you have with Pieces OS.
+This is a very simple guide on how to get up and running using the @pieces.app/pieces-os-client npm package and create a web environment that you can build on top of. **Fork this repo** to get started and learn about the depth of possibilities you have with Pieces OS.
 
 More guides will be coming soon around:
 - Creating a personal Copilot that understands your context

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "build": "react-scripts build"
   },
   "dependencies": {
-    "@pieces.app/client": "^1.0.0",
+    "@pieces.app/pieces-os-client": "^1.0.0",
     "@types/react": "^18.2.31",
     "@types/react-dom": "^18.2.14",
     "react-dom": "^18.2.0",

--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -1,7 +1,7 @@
 import * as React from "react";
 import {useState, useEffect} from "react";
-import * as Pieces from "@pieces.app/client";
-import {Application} from "@pieces.app/client";
+import * as Pieces from "@pieces.app/pieces-os-client";
+import {Application} from "@pieces.app/pieces-os-client";
 import {DataTextInput, DeleteAssetIDInput, RenameAssetInput} from './components/TextInput';
 import {Header} from './components/Header'
 import {connect} from './utils/Connect'

--- a/src/app/components/Asset.tsx
+++ b/src/app/components/Asset.tsx
@@ -1,6 +1,6 @@
-import * as Pieces from "@pieces.app/client";
-import {SeededAsset, SeedTypeEnum} from "@pieces.app/client";
-import {Application} from "@pieces.app/client";
+import * as Pieces from "@pieces.app/pieces-os-client";
+import {SeededAsset, SeedTypeEnum} from "@pieces.app/pieces-os-client";
+import {Application} from "@pieces.app/pieces-os-client";
 
 //==============================[/create]==================================//
 export function createAsset(applicationData: Application, data: string, name: string) {

--- a/src/app/components/Button.tsx
+++ b/src/app/components/Button.tsx
@@ -1,6 +1,5 @@
 import * as React from 'react';
 import { createAsset } from './Asset';
-import { Application } from '@pieces.app/client';
 
 export function CreateButton({applicationData, data, name}): React.JSX.Element {
   return (

--- a/src/app/utils/Connect.tsx
+++ b/src/app/utils/Connect.tsx
@@ -1,4 +1,4 @@
-import * as Pieces from "@pieces.app/client";
+import * as Pieces from "@pieces.app/pieces-os-client";
 
 // ============================ [/connect]=============================//
 const tracked_application = {


### PR DESCRIPTION
**Description**

This PR fixes #25 and is primarily maintenance + upgrade related to the new naming on the SDK. Primarily maintenance and also required an npm install which exposed some package dependencies that should be addressed. Those will come in a PR later. (#26)

Once this PR is in we will be migrated away from the incorrect naming convention we initially adopted and are consuming the new SDK location here: https://www.npmjs.com/package/@pieces.app/pieces-os-client

