### PR TITLE
Downgraded typescript from @>5 --> @<5 as reactscripts@5.0.1 requires typescript@^4

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "@types/node": "^20.8.7",
     "@types/react": "^18.2.43",
     "@types/react-dom": "^18.2.17",
-    "typescript": "^5.3.3"
+    "typescript": "^4.9.5"
   },
   "browserslist": {
     "production": [


### PR DESCRIPTION
**Description**

This PR fixes https://github.com/pieces-app/example-ts/pull/34 - there was an issue with the versions supported between two dependencies in relation to typescript - so the version has been downgraded. @derajohnson can you test this PR to see if you can run `npm install` & `npm run start` without any issues from a clean environment? 

I had some issues locally today and created this a solution. 