### PR TITLE
Implement Button Functionality for Launching Pieces OS

### DIFF
--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -65,14 +65,14 @@ export function App(): React.JSX.Element {
       }
     }).catch((error) => {
       console.error(error);
-      setError(error);
+      setError(true);
     });
   }
   
 
   return (
       <div style={{ padding: '10px 20px' }}>
-      <Header />
+      <Header isConnected={ !error} />
       {error && <div style={{border: '2px solid black',
         backgroundColor: '#0e1111',
           color: 'red',

--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -5,6 +5,7 @@ import {Application} from "@pieces.app/pieces-os-client";
 import {DataTextInput, DeleteAssetButton, RenameAssetInput} from './components/TextInput';
 import {Header} from './components/Header'
 import {connect} from './utils/Connect'
+import { Indicator } from "./components/Indicator";
 
 // types
 type LocalAsset = {
@@ -192,13 +193,4 @@ connect().then(__ => {
   }
   //agrim implemented - Upon connecting to the Pieces OS, there is a need to enhance the user experience by implementing a timer 
   //that automatically hides the "You're Connected" text and shrinks the button after a certain duration
-  let time = 3000;
-  setTimeout(() => {
-    if (_indicator != null) {
-      let indicatorText = document.getElementById("indicator_text");
-      indicatorText.innerText = "";
-      _indicator.style.transition = "all 0.3s ease";
-      _indicator.style.transform = "scale(0.8)";
-    }
-  }, time);
 })

--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -81,7 +81,7 @@ export function App(): React.JSX.Element {
           padding: '20px',
           borderRadius: '9px',
           display: "flex",
-        boxShadow: '-4px 4px 5px rgba(0,0,0, 0.2)',marginBottom:"10px"}}> Pieces OS is not running in the background. Click You're Connected to connect </div>}
+        boxShadow: '-4px 4px 5px rgba(0,0,0, 0.2)',marginBottom:"10px"}}> Pieces OS is not running in the background. Click You're Not Connected to connect </div>}
         <div style={{
           // width: "auto",
           border: '2px solid black',
@@ -203,6 +203,7 @@ connect().then(__ => {
   if (_indicator != null) {
     __ != undefined ? _indicator.style.backgroundColor = "green" : _indicator.style.backgroundColor = "red";
   }
+  _indicator.firstElementChild.innerHTML = __ != undefined ? "You're Connected!" : "You're Not Connected";
   //agrim implemented - Upon connecting to the Pieces OS, there is a need to enhance the user experience by implementing a timer 
   //that automatically hides the "You're Connected" text and shrinks the button after a certain duration
 })

--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -30,6 +30,7 @@ export function App(): React.JSX.Element {
 
   const [array, setArray] = useState<Array<LocalAsset>>([]);
   const [selectedIndex, setSelectedIndex] = useState<number>(-1);
+  const [error, setError] = useState(null);
 
   const refresh = (_newAsset: LocalAsset) => {
     setArray(prevArray => [...prevArray, _newAsset])
@@ -62,14 +63,25 @@ export function App(): React.JSX.Element {
         refresh(_local);
 
       }
-    })
-    
+    }).catch((error) => {
+      console.error(error);
+      setError(error);
+    });
   }
+  
 
   return (
       <div style={{ padding: '10px 20px' }}>
-          <Header />
-
+      <Header />
+      {error && <div style={{border: '2px solid black',
+        backgroundColor: '#0e1111',
+          color: 'red',
+          minWidth: '1175px',
+          maxWidth: '1175px',
+          padding: '20px',
+          borderRadius: '9px',
+          display: "flex",
+        boxShadow: '-4px 4px 5px rgba(0,0,0, 0.2)',marginBottom:"10px"}}> Pieces OS is not running in the background. Click You're Connected to connect </div>}
         <div style={{
           // width: "auto",
           border: '2px solid black',

--- a/src/app/components/Header.tsx
+++ b/src/app/components/Header.tsx
@@ -20,11 +20,15 @@ import { Indicator } from "./Indicator"
 //
 
 // this is the header element with its children:
-export function Header(): React.JSX.Element {
+interface HeaderProps {
+  isConnected: boolean
+}
+
+export function Header({isConnected}:HeaderProps): React.JSX.Element {
   return (
       <div style={{ display: 'flex', flexDirection: "row", justifyContent: 'space-between', alignItems: 'center', backgroundColor: 'black', padding: '0px 10px', marginBottom: '1rem', boxShadow: '-4px 4px 5px rgba(0,0,0, 0.2)', borderRadius: '10px', minWidth: '1200px', maxWidth: '1200px'}}>
         <h3 style={{color: 'white', fontWeight: 'normal' }}>Pieces OS Client SDK for Typescript<span style={{ fontSize: '8px', marginLeft: '5px', fontWeight: '100' }}>Open Source by Pieces</span></h3>
-        <Indicator />
+      <Indicator isConnected={ isConnected} />
       </div>
   )
 }

--- a/src/app/components/Indicator.tsx
+++ b/src/app/components/Indicator.tsx
@@ -4,13 +4,17 @@ import * as React from "react";
 import check from "../icons/check.png";
 import { launchPiecesOS } from "../utils/launchPiecesOS";
 
-export function Indicator(): React.JSX.Element {
+interface IndicatorProps{
+  isConnected: boolean
+}
+
+export function Indicator({isConnected}:IndicatorProps): React.JSX.Element {
   return (
     <>
       <div style={{ display: "inherit", justifyContent: 'center', alignItems: 'center' }}>
         <button style={{background:"transparent", border: '1px solid black'}}>
-          <div id={"indicator"} style={{ backgroundColor: "red", height: '24px', borderRadius: '20px', border: '1px solid black', padding: '4px 10px', display: 'flex', flexWrap: 'wrap', alignItems: 'center'  }} onClick={launchPiecesOS}>
-            <span id={"indicator_text"} style={{ color: "white", fontSize: '14px' }}>You're Not Connected!</span>
+          <div id={"indicator"} style={{ backgroundColor: isConnected?"Green":"red" , height: '24px', borderRadius: '20px', border: '1px solid black', padding: '4px 10px', display: 'flex', flexWrap: 'wrap', alignItems: 'center'  }} onClick={launchPiecesOS}>
+            <span id={"indicator_text"} style={{ color: "white", fontSize: '14px' }}>{isConnected?"You're Connected":"You're Not Connected"  }</span>
             <img id={"checkmark"} src={check} alt={"checkmark"} style={{height: "20px", width: '20px', margin: '0 5px'}}/>
           </div>
         </button>

--- a/src/app/components/Indicator.tsx
+++ b/src/app/components/Indicator.tsx
@@ -2,31 +2,19 @@ import * as React from "react";
 
 // @ts-ignore
 import check from "../icons/check.png";
-
-// this is your indicator badge that we will manipulate through the initial connect call. it will either
-// be green or red depending on the current status.
-
-// (4) So in your designs I saw that you wanted to add the 'text connected and secured' and a check to the circle indicator.
-// this should be pretty simple to add in with a few steps:
-//
-// a. First lets get the icon for the check mark - I got one from icons 8 here: https://icons8.com/icon/set/check/color
-// b. Now lets move the text inside the pill here that you suggested
-// c. then add the <img> element after the <span> you just added, styled it, and TODO: I added a ts-ignore above the image import (cant get it to go away)
-// d. added an id to the image for later and we are good to go for now.
-//
-// lets head over to the App.tsx file at /app/App.tsx and we can get going on rearranging some pieces and parts of this
-// landing index page.
+import { launchPiecesOS } from "../utils/launchPiecesOS";
 
 export function Indicator(): React.JSX.Element {
   return (
-      <>
-          <div style={{ display: "inherit", justifyContent: 'center', alignItems: 'center' }}>
-              {/*<p style={{ paddingRight: '10px' }}>Connection Status</p>*/}
-              <div id={"indicator"} style={{ backgroundColor: "red", height: '24px', borderRadius: '20px', border: '1px solid black', padding: '2px 10px', display: 'flex', flexWrap: 'wrap', alignItems: 'center'  }}>
-                <span id={"indicator_text"} style={{ color: "white", fontSize: '14px' }}>You're Connected!</span>
-                <img id={"checkmark"} src={check} alt={"checkmark"} style={{height: "20px", width: '20px', margin: '0 5px'}}/>
-              </div>
+    <>
+      <div style={{ display: "inherit", justifyContent: 'center', alignItems: 'center' }}>
+        <button style={{background:"transparent", border: '1px solid black'}}>
+          <div id={"indicator"} style={{ backgroundColor: "red", height: '24px', borderRadius: '20px', border: '1px solid black', padding: '4px 10px', display: 'flex', flexWrap: 'wrap', alignItems: 'center'  }} onClick={launchPiecesOS}>
+            <span id={"indicator_text"} style={{ color: "white", fontSize: '14px' }}>You're Connected!</span>
+            <img id={"checkmark"} src={check} alt={"checkmark"} style={{height: "20px", width: '20px', margin: '0 5px'}}/>
           </div>
-      </>
-  )
+        </button>
+      </div>
+    </>
+  );
 }

--- a/src/app/components/Indicator.tsx
+++ b/src/app/components/Indicator.tsx
@@ -10,7 +10,7 @@ export function Indicator(): React.JSX.Element {
       <div style={{ display: "inherit", justifyContent: 'center', alignItems: 'center' }}>
         <button style={{background:"transparent", border: '1px solid black'}}>
           <div id={"indicator"} style={{ backgroundColor: "red", height: '24px', borderRadius: '20px', border: '1px solid black', padding: '4px 10px', display: 'flex', flexWrap: 'wrap', alignItems: 'center'  }} onClick={launchPiecesOS}>
-            <span id={"indicator_text"} style={{ color: "white", fontSize: '14px' }}>You're Connected!</span>
+            <span id={"indicator_text"} style={{ color: "white", fontSize: '14px' }}>You're Not Connected!</span>
             <img id={"checkmark"} src={check} alt={"checkmark"} style={{height: "20px", width: '20px', margin: '0 5px'}}/>
           </div>
         </button>

--- a/src/app/utils/launchPiecesOS.tsx
+++ b/src/app/utils/launchPiecesOS.tsx
@@ -1,6 +1,6 @@
 import { connect } from './Connect';; // Import the Promise type
 
-const launchPiecesOS = () => {
+const launchPiecesOS = async () => {
   const url: string = 'pieces://launch';
   try {
     const isPiecesOSConnected = navigator.userAgent.includes('PiecesOS');
@@ -8,12 +8,27 @@ const launchPiecesOS = () => {
       console.log("Pieces OS is already connected.");
       // Perform any additional actions for connected state
     } else {
-      window.open(url, '_blank');
+      await window.open(url, '_blank');
       console.log("Pieces OS is installed.");
       window.location.reload();// Refresh the page
     }
   } catch {
     console.error("Pieces OS is not installed.");
+  }
+  finally {
+    connect().then((data: JSON) => {
+      // define the indicator now that it exists.
+      const _indicator = document.getElementById("indicator");
+
+      // conditional for the response back on application.
+      //
+      // (1) first @jordan-pieces came in here and added this turing statement here inside a new
+      // if statement. this is an upgrade in comparison to the previous if statement that would not check to
+      // see if the _indicator itself is added to the DOM yet.
+      if (_indicator != null) {
+        _indicator != undefined ? _indicator.style.backgroundColor = "green" : _indicator.style.backgroundColor = "red";
+      }
+    })
   } // Add a missing closing parenthesis and semicolon here
 }
 export { launchPiecesOS };

--- a/src/app/utils/launchPiecesOS.tsx
+++ b/src/app/utils/launchPiecesOS.tsx
@@ -1,0 +1,19 @@
+import { connect } from './Connect';; // Import the Promise type
+
+const launchPiecesOS = () => {
+  const url: string = 'pieces://launch';
+  try {
+    const isPiecesOSConnected = navigator.userAgent.includes('PiecesOS');
+    if (isPiecesOSConnected) {
+      console.log("Pieces OS is already connected.");
+      // Perform any additional actions for connected state
+    } else {
+      window.open(url, '_blank');
+      console.log("Pieces OS is installed.");
+      window.location.reload();// Refresh the page
+    }
+  } catch {
+    console.error("Pieces OS is not installed.");
+  } // Add a missing closing parenthesis and semicolon here
+}
+export { launchPiecesOS };

--- a/src/app/utils/launchPiecesOS.tsx
+++ b/src/app/utils/launchPiecesOS.tsx
@@ -28,6 +28,7 @@ const launchPiecesOS = async () => {
       if (_indicator != null) {
         _indicator != undefined ? _indicator.style.backgroundColor = "green" : _indicator.style.backgroundColor = "red";
       }
+      _indicator.firstElementChild.innerHTML = _indicator != undefined ? "You're Connected!" : "You're Not Connected";
     })
   } // Add a missing closing parenthesis and semicolon here
 }


### PR DESCRIPTION
**Description**
Implement Button Functionality for Launching Pieces OS
This PR fixed #41
Problem Statement:
Currently, when Pieces OS is not connected, the UI lacks a functional aspect to initiate the connection. To improve user interaction, we want to add button functionality to the "Not Connected" button, allowing users to launch Pieces OS by clicking it.

Expected Outcome:
Users will be able to launch Pieces OS by clicking the "Not Connected" button, enhancing the user experience and providing a straightforward way to establish a connection.

<!--
Thank you for contributing to the Pieces TypeScript SDK sample project

Contributing Conventions:

1. Include descriptive PR titles.
2. Build and test your changes before submitting a PR.

-->