### PR TITLE
Connect to Pieces OS Using provided Connector.Api endpoint

### DIFF
--- a/src/app/utils/Connect.tsx
+++ b/src/app/utils/Connect.tsx
@@ -2,30 +2,17 @@ import * as Pieces from "@pieces.app/pieces-os-client";
 
 // ============================ [/connect]=============================//
 const tracked_application = {
-  name: Pieces.ApplicationNameEnum.Brave,
+  name: Pieces.ApplicationNameEnum.Unknown,
   version: '0.0.1',
   platform: Pieces.PlatformEnum.Macos,
 }
 // TODO: this will need to be updated once we are further along with the connector work.
 export async function connect(): Promise<JSON> {
-
-  const url: string = 'http://localhost:1000/connect';
-  const options: {method: string, body: string} = {
-      method: 'POST',
-      body: JSON.stringify({ application: tracked_application}
-      ),
-  }
-
-  let _output: Promise<JSON>;
-
-  try {
-      const response: Response = await fetch(url, options);
-      const data: Promise<JSON> = await response.json();
-      _output = data;
-      return _output;
-  } catch (e) {
-      console.error(e);
-  }
-
+  const connectorApi = new Pieces.ConnectorApi();
+  const response = await connectorApi.connect({
+    seededConnectorConnection: { application: tracked_application },
+  });
+  //  console.log(response); you can log response just to confirm
+  return JSON.parse(JSON.stringify(response));
 }
 // ============================ [.end /connect]=============================//


### PR DESCRIPTION
**Connect to Pieces using the `Connector.Api`endpoint**

This PR provides an easier and more efficient way to connect your application to Pieces OS and utilize its functionalities.
